### PR TITLE
docs: update README and add doc maintenance rule to evolution prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,45 @@ Bloom is a proof-of-concept demonstrating that an AI agent can **safely and tran
 Every 4 hours, Bloom runs an evolution cycle via GitHub Actions:
 
 1. **Pre-flight** - Verifies build and tests pass before starting
-2. **Assessment** - Reads its own code, community issues, and journal to identify improvements
-3. **Evolution** - Implements 1-3 improvements, testing each before committing
-4. **Build verification** - Verifies build still passes after evolution; reverts if broken
-5. **Journal** - Documents what was attempted, what succeeded, and what was learned
-6. **Push** - Pushes passing changes to main
+2. **Memory & Planning** - Loads accumulated learnings, strategic context, and the project roadmap
+3. **Assessment** - Reads its own code, community issues, memory, and roadmap to identify improvements
+4. **Evolution** - Implements 1-3 improvements, testing each before committing
+5. **Build verification** - Verifies build still passes after evolution; reverts if broken
+6. **Learning extraction** - Stores categorized learnings and updates strategic context
+7. **Roadmap update** - Updates the GitHub Project board with cycle results
+8. **Push** - Pushes passing changes to main
 
 The workflow retries up to 3 times with backoff on failure.
+
+## Features
+
+### Memory
+
+Bloom accumulates knowledge across evolution cycles via two mechanisms:
+
+- **Structured learnings** — Categorized insights (pattern, anti-pattern, domain, tool-usage) stored in SQLite with relevance decay. Newer learnings naturally rank higher than older ones. Injected into each assessment prompt so Bloom builds on past experience.
+- **Strategic context** — A persistent narrative summary of focus areas, trajectory, and ongoing goals. Updated each cycle so Bloom maintains awareness of its multi-cycle direction.
+
+### Planning via GitHub Projects
+
+Bloom manages its own **kanban-style roadmap** using a GitHub Projects v2 board ("Bloom Evolution Roadmap"):
+
+- **Hybrid planning** — Bloom proposes its own improvement goals and incorporates community issues, with reactions influencing priority
+- **Automated status tracking** — Items flow from Backlog → Up Next → In Progress → Done as Bloom works through cycles
+- **Priority algorithm** — "Up Next" items are picked first (sorted by reactions), then "Backlog" items
+
+### Persistence
+
+All state is stored in `bloom.db` (SQLite with WAL mode):
+
+| Table | Purpose |
+|-------|---------|
+| `cycles` | One row per evolution cycle with outcome metrics |
+| `journal_entries` | Structured journal data (attempted, succeeded, failed, learnings) |
+| `phase_usage` | Token counts, costs, and duration per phase |
+| `issue_actions` | Tracks which issues were acknowledged or closed |
+| `learnings` | Categorized knowledge with relevance scores |
+| `strategic_context` | High-level narrative summaries per cycle |
 
 ## Safety
 
@@ -33,6 +65,7 @@ The workflow retries up to 3 times with backoff on failure.
 - **Append-only journal** - `JOURNAL.md` can only be appended to, never overwritten
 - **Dangerous command blocking** - Safety hooks prevent `rm -rf`, force pushes, etc.
 - **Budget limits** - Max 50 turns and $5 per evolution cycle
+- **Best-effort externals** - GitHub API failures (issues, projects) never block evolution
 
 ## Journal
 
@@ -40,7 +73,24 @@ The full evolution journal is published at the repo's [GitHub Pages site](https:
 
 ## Community Input
 
-Open an issue with the `agent-input` label to suggest improvements. Issues are prioritized by reaction count.
+Open an issue with the `agent-input` label to suggest improvements. Issues are prioritized by reaction count. Bloom acknowledges each issue with a comment and can auto-close issues when commits reference them.
+
+## Architecture
+
+```
+src/
+├── index.ts        # Main orchestrator (5 phases)
+├── evolve.ts       # Assessment & evolution prompt building
+├── memory.ts       # Learning extraction, storage, and prompt formatting
+├── planning.ts     # GitHub Projects v2 integration via GraphQL
+├── db.ts           # SQLite persistence (bloom.db)
+├── issues.ts       # GitHub issues integration
+├── github-app.ts   # GitHub App JWT auth + REST/GraphQL API client
+├── safety.ts       # Pre-tool-use hooks & dangerous command blocking
+├── lifecycle.ts    # Git operations, build verification, safety tags
+├── outcomes.ts     # Cycle metrics tracking
+└── usage.ts        # Token/cost usage tracking
+```
 
 ## GitHub Actions
 
@@ -51,9 +101,15 @@ Evolution runs automatically on a 4-hour cron schedule. You can also trigger it 
 | Secret | Description |
 |--------|-------------|
 | `ANTHROPIC_API_KEY` | Anthropic API key for Claude |
-| `BLOOM_APP_PRIVATE_KEY` | GitHub App private key (PEM) for bot issue comments |
+| `BLOOM_APP_PRIVATE_KEY` | GitHub App private key (PEM) for issue management and project board |
 
 `GITHUB_TOKEN` is provided automatically by GitHub Actions.
+
+### GitHub App Permissions
+
+The GitHub App (used for issue and project management) needs:
+- **Issues**: Read and write
+- **Projects**: Read and write
 
 ## Local Development
 

--- a/src/evolve.ts
+++ b/src/evolve.ts
@@ -156,6 +156,7 @@ RULES:
 5. NEVER modify IDENTITY.md.
 6. Do NOT write to JOURNAL.md — journal entries are now stored in SQLite and managed by the orchestrator.
 7. Keep changes small and incremental.
+8. After completing code changes, update README.md and any other public-facing documentation to accurately reflect the current state of the agent — its features, architecture, and capabilities. Do not leave docs stale.
 
 After all improvements, end your response with a structured summary using EXACTLY this format (no markdown headers, no bold, just the marker followed by a colon):
 


### PR DESCRIPTION
- Update README.md to reflect current features: memory (structured learnings + strategic context), planning (GitHub Projects v2 board), persistence tables, architecture diagram, and App permissions
- Add rule 8 to evolution prompt: bloom must update README and other public-facing docs after code changes to keep them current

https://claude.ai/code/session_01CLksLfVDmHu1gxd4JrRysL