### PR TITLE
fix: countImprovements now handles N) format and inline numbered items

### DIFF
--- a/src/evolve.ts
+++ b/src/evolve.ts
@@ -103,18 +103,26 @@ export function parseEvolutionResult(result: string): Record<string, string> {
 
 /**
  * Count the number of improvement items in a section text.
- * Counts lines starting with "- " or numbered items like "1. ", "2. ".
+ * Counts lines starting with "- " or numbered items like "1. ", "2. ", "1) ".
+ * Also counts inline numbered items (e.g., "1) foo. 2) bar. 3) baz" on one line).
  */
 export function countImprovements(text: string): number {
   if (!text) return 0;
-  let count = 0;
+
+  // Count lines starting with "- ", "N. ", or "N) "
+  let lineCount = 0;
   for (const line of text.split("\n")) {
     const trimmed = line.trim();
-    if (trimmed.match(/^(?:-|\d+\.)\s+/)) {
-      count++;
+    if (trimmed.match(/^(?:-|\d+[.)]\s)/)) {
+      lineCount++;
     }
   }
-  return count;
+
+  // Also count all numbered items throughout text (catches inline "1) foo. 2) bar")
+  const inlineMatches = text.match(/(?:^|[\s,;(])\d+[.)]\s/gm);
+  const inlineCount = inlineMatches ? inlineMatches.length : 0;
+
+  return Math.max(lineCount, inlineCount);
 }
 
 /**

--- a/tests/evolve.test.ts
+++ b/tests/evolve.test.ts
@@ -269,6 +269,22 @@ describe("countImprovements", () => {
   it("handles indented bullets", () => {
     expect(countImprovements("  - Indented item\n  1. Another")).toBe(2);
   });
+
+  it("counts N) format on separate lines", () => {
+    expect(countImprovements("1) First\n2) Second\n3) Third")).toBe(3);
+  });
+
+  it("counts inline numbered items with N) format", () => {
+    expect(countImprovements("1) Include strategic_context. 2) Add cache tokens. 3) Remove fallback.")).toBe(3);
+  });
+
+  it("counts inline numbered items with N. format", () => {
+    expect(countImprovements("1. First item, 2. second item, 3. third item")).toBe(3);
+  });
+
+  it("counts inline items preceded by prose", () => {
+    expect(countImprovements("All three succeeded. 1) Added field. 2) Updated usage. 3) Removed fallback.")).toBe(3);
+  });
 });
 
 describe("extractResolvedIssueNumbers", () => {


### PR DESCRIPTION
The function only matched `N. ` and `- ` at line starts, causing cycles 51-57
to record 0/0 improvements despite journal entries showing successful work.
Now also matches `N)` format and counts inline numbered items (e.g.,
"1) foo. 2) bar. 3) baz" on a single line).

https://claude.ai/code/session_01Nmq89mnWMuSyPepex6LYuN