### PR TITLE
Add issue triage system to automatically categorize community issues

### DIFF
--- a/src/evolve.ts
+++ b/src/evolve.ts
@@ -1,9 +1,6 @@
-import type { CommunityIssue } from "./issues.js";
-
 export interface AssessmentContext {
   identity: string;
   journalSummary: string;
-  issues: CommunityIssue[];
   cycleCount: number;
   cycleStatsText?: string;
   memoryContext?: string;
@@ -11,19 +8,11 @@ export interface AssessmentContext {
 }
 
 export function buildAssessmentPrompt(ctx: AssessmentContext): string {
-  const issueList =
-    ctx.issues.length > 0
-      ? ctx.issues
-          .map((i) => `- #${i.number}: ${i.title} (${i.reactions} reactions)`)
-          .join("\n")
-      : "No community issues.";
-
   return `You are Bloom, a self-evolving coding agent. This is evolution cycle ${ctx.cycleCount}.
 
 Read your own source code in src/ and assess what to improve. Consider:
 1. Bugs or correctness issues
-2. Community requests (prioritized by reactions):
-${issueList}
+2. Items on the project board (see Evolution Roadmap below)
 3. Test coverage gaps
 4. Code clarity improvements
 5. New capabilities aligned with your purpose
@@ -169,7 +158,7 @@ RULES:
 After all improvements, end your response with a structured summary using EXACTLY this format (no markdown headers, no bold, just the marker followed by a colon):
 
 ATTEMPTED: <what was attempted>
-SUCCEEDED: <what succeeded — IMPORTANT: if any improvement addresses a community issue, you MUST reference it as #N (e.g. "Added token tracking (#4)") so the orchestrator can auto-close it>
+SUCCEEDED: <what succeeded>
 FAILED: <what failed>
 LEARNINGS: <key insights — optionally prefix each with [pattern], [anti-pattern], [domain], or [tool-usage]>
 STRATEGIC_CONTEXT: <2-4 sentences about your current focus areas, trajectory, and ongoing goals>`;

--- a/src/evolve.ts
+++ b/src/evolve.ts
@@ -169,7 +169,7 @@ RULES:
 After all improvements, end your response with a structured summary using EXACTLY this format (no markdown headers, no bold, just the marker followed by a colon):
 
 ATTEMPTED: <what was attempted>
-SUCCEEDED: <what succeeded>
+SUCCEEDED: <what succeeded — IMPORTANT: if any improvement addresses a community issue, you MUST reference it as #N (e.g. "Added token tracking (#4)") so the orchestrator can auto-close it>
 FAILED: <what failed>
 LEARNINGS: <key insights — optionally prefix each with [pattern], [anti-pattern], [domain], or [tool-usage]>
 STRATEGIC_CONTEXT: <2-4 sentences about your current focus areas, trajectory, and ongoing goals>`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { readFileSync } from "fs";
 import { initDb, getLatestCycleNumber, insertCycle, updateCycleOutcome, insertPhaseUsage, getRecentJournalSummary, getCycleStats, formatCycleStats } from "./db.js";
-import { fetchCommunityIssues, acknowledgeIssues } from "./issues.js";
+import { fetchCommunityIssues } from "./issues.js";
+import { triageIssues } from "./triage.js";
 import { buildAssessmentPrompt, buildEvolutionPrompt } from "./evolve.js";
 import {
   protectIdentity,
@@ -99,11 +100,30 @@ async function main() {
         console.log(`[planning] Project found (id: ${projectConfig.projectId.slice(0, 20)}...)`);
         console.log(`[planning] Status field: ${projectConfig.statusFieldId.slice(0, 20)}...`);
         console.log(`[planning] Status columns: ${[...projectConfig.statusOptions.keys()].join(", ")}`);
-        const projectItems = await getProjectItems(projectConfig);
+        let projectItems = await getProjectItems(projectConfig);
         console.log(`[planning] ${projectItems.length} items on board`);
         for (const item of projectItems) {
           console.log(`  - [${item.status ?? "No Status"}] ${item.title}${item.reactions > 0 ? ` (${item.reactions} reactions)` : ""}`);
         }
+
+        // Triage community issues against the board
+        if (issues.length > 0) {
+          console.log(`\n[triage] Triaging ${issues.length} community issues against project board...`);
+          const triageResult = await triageIssues(issues, projectItems, cycleCount, projectConfig, db);
+          if (triageResult.addedToBacklog.length > 0) {
+            console.log(`[triage] Added to backlog: ${triageResult.addedToBacklog.map(n => `#${n}`).join(", ")}`);
+          }
+          if (triageResult.closed.length > 0) {
+            console.log(`[triage] Closed: ${triageResult.closed.map(n => `#${n}`).join(", ")}`);
+          }
+          for (const d of triageResult.decisions) {
+            console.log(`  - #${d.issueNumber}: ${d.action} — ${d.reason.slice(0, 100)}`);
+          }
+          // Re-fetch board items since triage may have added new ones
+          projectItems = await getProjectItems(projectConfig);
+          console.log(`[planning] ${projectItems.length} items on board (post-triage)`);
+        }
+
         currentItem = pickNextItem(projectItems);
         if (currentItem) {
           console.log(`[planning] Selected: "${currentItem.title}" → marking In Progress`);
@@ -128,7 +148,7 @@ async function main() {
     const phaseUsages: PhaseUsage[] = [];
     let assessmentTurns = 0;
     for await (const msg of query({
-      prompt: buildAssessmentPrompt({ identity, journalSummary, issues, cycleCount, cycleStatsText, memoryContext, planningContext }),
+      prompt: buildAssessmentPrompt({ identity, journalSummary, cycleCount, cycleStatsText, memoryContext, planningContext }),
       options: {
         cwd: process.cwd(),
         model: "claude-opus-4-6",
@@ -155,11 +175,6 @@ async function main() {
 
     console.log(`\n[assessment] Completed in ${(assessmentMs / 1000).toFixed(1)}s (${assessmentTurns} turns, ${assessment.length} chars)`);
     console.log(`[assessment] Output preview:\n${assessment.slice(0, 500)}${assessment.length > 500 ? "\n  ..." : ""}`);
-
-    // Acknowledge all community issues so contributors see their input was seen.
-    console.log(`\n[issues] Acknowledging ${issues.length} community issues...`);
-    await acknowledgeIssues(issues, cycleCount, db);
-    console.log("[issues] Done.");
 
     // Phase 2: Evolution (read-write with safety hooks)
     console.log("\n========================================");
@@ -211,7 +226,7 @@ async function main() {
 
     // Process evolution result: parse journal, store learnings, close resolved issues
     console.log("\n[journal] Processing evolution result...");
-    const processed = await processEvolutionResult(db, cycleCount, evolutionResult, issues);
+    const processed = await processEvolutionResult(db, cycleCount, evolutionResult);
     for (const [section, content] of Object.entries(processed.journalSections)) {
       if (content) {
         console.log(`[journal] Stored section "${section}" (${content.length} chars)`);
@@ -224,9 +239,6 @@ async function main() {
     outcome.improvementsAttempted = processed.improvementsAttempted;
     outcome.improvementsSucceeded = processed.improvementsSucceeded;
     console.log(`[outcome] Improvements: ${outcome.improvementsSucceeded}/${outcome.improvementsAttempted} succeeded`);
-    if (processed.issuesClosed.length > 0) {
-      console.log(`[issues] Closed resolved issues: ${processed.issuesClosed.map(n => `#${n}`).join(", ")}`);
-    }
 
     // Phase 2.5: Post-evolution build verification
     console.log("\n========================================");

--- a/src/issues.ts
+++ b/src/issues.ts
@@ -148,26 +148,27 @@ export function hasCommitForIssue(issueNumber: number): boolean {
 }
 
 /**
- * Close a resolved issue with a comment explaining the resolution.
+ * Close an issue with a comment. Generic helper used by triage and legacy resolution.
  * Best-effort — failures are swallowed to never block evolution.
  */
-export async function closeResolvedIssue(
+export async function closeIssueWithComment(
   issueNumber: number,
   cycleCount: number,
-  reason: string,
+  comment: string,
   db?: Database.Database,
+  action: string = "closed",
 ): Promise<boolean> {
   const repo = detectRepo();
   if (!repo || !isValidRepo(repo)) return false;
   if (!isSafeIssueNumber(issueNumber)) return false;
 
-  // Skip if already closed locally
-  if (db && hasIssueAction(db, issueNumber, "closed")) return true;
+  // Skip if already performed this action locally
+  if (db && hasIssueAction(db, issueNumber, action)) return true;
 
   try {
     // Post closing comment
     await githubApiRequest("POST", `/repos/${repo}/issues/${issueNumber}/comments`, {
-      body: `Resolved by Bloom in cycle ${cycleCount}.\n\n${reason}`,
+      body: comment,
     });
 
     // Close the issue
@@ -175,11 +176,21 @@ export async function closeResolvedIssue(
       state: "closed",
     });
 
-    // Record the close action
-    if (db) insertIssueAction(db, cycleCount, issueNumber, "closed");
+    // Record the action
+    if (db) insertIssueAction(db, cycleCount, issueNumber, action);
 
     return true;
   } catch {
     return false;
   }
+}
+
+/** @deprecated Use closeIssueWithComment instead */
+export async function closeResolvedIssue(
+  issueNumber: number,
+  cycleCount: number,
+  reason: string,
+  db?: Database.Database,
+): Promise<boolean> {
+  return closeIssueWithComment(issueNumber, cycleCount, `Resolved by Bloom in cycle ${cycleCount}.\n\n${reason}`, db, "closed");
 }

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -2,7 +2,7 @@ import type Database from "better-sqlite3";
 import { insertJournalEntry } from "./db.js";
 import { parseEvolutionResult, countImprovements, extractResolvedIssueNumbers } from "./evolve.js";
 import { extractLearnings, storeLearnings, storeStrategicContext } from "./memory.js";
-import { closeResolvedIssue, hasCommitForIssue, type CommunityIssue } from "./issues.js";
+import { closeResolvedIssue, type CommunityIssue } from "./issues.js";
 import type { CycleOutcome } from "./outcomes.js";
 
 /**
@@ -63,16 +63,16 @@ export async function processEvolutionResult(
   const improvementsAttempted = countImprovements(journalSections.attempted);
   const improvementsSucceeded = countImprovements(journalSections.succeeded);
 
-  // Close issues mentioned in the succeeded section that have associated commits
+  // Close issues mentioned in the succeeded section.
+  // The agent's SUCCEEDED summary is the primary signal — if it reports resolving
+  // an issue, trust it (the work already passed build+test verification).
   const openIssueNumbers = issues.map(i => i.number);
   const resolvedNumbers = extractResolvedIssueNumbers(journalSections.succeeded, openIssueNumbers);
   const issuesClosed: number[] = [];
   for (const issueNum of resolvedNumbers) {
-    if (hasCommitForIssue(issueNum)) {
-      const issue = issues.find(i => i.number === issueNum);
-      await closeResolvedIssue(issueNum, cycleCount, `Addressed: ${issue?.title ?? `issue #${issueNum}`}`, db);
-      issuesClosed.push(issueNum);
-    }
+    const issue = issues.find(i => i.number === issueNum);
+    await closeResolvedIssue(issueNum, cycleCount, `Addressed: ${issue?.title ?? `issue #${issueNum}`}`, db);
+    issuesClosed.push(issueNum);
   }
 
   return {

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,8 +1,7 @@
 import type Database from "better-sqlite3";
 import { insertJournalEntry } from "./db.js";
-import { parseEvolutionResult, countImprovements, extractResolvedIssueNumbers } from "./evolve.js";
+import { parseEvolutionResult, countImprovements } from "./evolve.js";
 import { extractLearnings, storeLearnings, storeStrategicContext } from "./memory.js";
-import { closeResolvedIssue, type CommunityIssue } from "./issues.js";
 import type { CycleOutcome } from "./outcomes.js";
 
 /**
@@ -14,20 +13,18 @@ export interface ProcessedEvolution {
   improvementsSucceeded: number;
   learningsStored: number;
   strategicContextStored: boolean;
-  issuesClosed: number[];
 }
 
 /**
  * Process the raw evolution result text: parse journal sections, store learnings,
- * store strategic context, count improvements, and close resolved issues.
+ * store strategic context, and count improvements.
  *
- * Extracted from index.ts main() to enable unit testing.
+ * Issue lifecycle is now handled by the triage step (src/triage.ts), not here.
  */
 export async function processEvolutionResult(
   db: Database.Database,
   cycleCount: number,
   evolutionResult: string,
-  issues: CommunityIssue[],
 ): Promise<ProcessedEvolution> {
   // Parse journal sections from evolution result
   const journalSections = parseEvolutionResult(evolutionResult);
@@ -63,25 +60,12 @@ export async function processEvolutionResult(
   const improvementsAttempted = countImprovements(journalSections.attempted);
   const improvementsSucceeded = countImprovements(journalSections.succeeded);
 
-  // Close issues mentioned in the succeeded section.
-  // The agent's SUCCEEDED summary is the primary signal — if it reports resolving
-  // an issue, trust it (the work already passed build+test verification).
-  const openIssueNumbers = issues.map(i => i.number);
-  const resolvedNumbers = extractResolvedIssueNumbers(journalSections.succeeded, openIssueNumbers);
-  const issuesClosed: number[] = [];
-  for (const issueNum of resolvedNumbers) {
-    const issue = issues.find(i => i.number === issueNum);
-    await closeResolvedIssue(issueNum, cycleCount, `Addressed: ${issue?.title ?? `issue #${issueNum}`}`, db);
-    issuesClosed.push(issueNum);
-  }
-
   return {
     journalSections,
     improvementsAttempted,
     improvementsSucceeded,
     learningsStored,
     strategicContextStored,
-    issuesClosed,
   };
 }
 

--- a/src/planning.ts
+++ b/src/planning.ts
@@ -194,6 +194,73 @@ export function extractProjectConfig(project: ProjectShape): ProjectConfig | nul
 // --- Item CRUD ---
 
 /**
+ * Resolve a GitHub issue number to its GraphQL node ID.
+ */
+export async function getIssueNodeId(
+  repo: string,
+  issueNumber: number,
+): Promise<string | null> {
+  const [owner, name] = repo.split("/");
+  if (!owner || !name) return null;
+
+  const query = `
+    query($owner: String!, $name: String!, $number: Int!) {
+      repository(owner: $owner, name: $name) {
+        issue(number: $number) { id }
+      }
+    }
+  `;
+
+  try {
+    const result = await githubGraphQL(query, { owner, name, number: issueNumber });
+    return (result.data as Record<string, { issue?: { id: string } }>)?.repository?.issue?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Add a real GitHub issue to the project board (linked, not a draft).
+ * Falls back to addDraftItem if the issue can't be linked.
+ */
+export async function addLinkedItem(
+  config: ProjectConfig,
+  repo: string,
+  issueNumber: number,
+  title: string,
+  body: string,
+  status: StatusColumn = "Backlog",
+): Promise<string | null> {
+  const nodeId = await getIssueNodeId(repo, issueNumber);
+  if (!nodeId) {
+    // Fall back to draft item
+    return addDraftItem(config, `#${issueNumber}: ${title}`, body, status);
+  }
+
+  const mutation = `
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+        item { id }
+      }
+    }
+  `;
+
+  try {
+    const result = await githubGraphQL(mutation, {
+      projectId: config.projectId,
+      contentId: nodeId,
+    });
+    const itemId = (result.data as Record<string, { item?: { id: string } }>)?.addProjectV2ItemById?.item?.id;
+    if (!itemId) return addDraftItem(config, `#${issueNumber}: ${title}`, body, status);
+
+    await updateItemStatus(config, itemId, status);
+    return itemId;
+  } catch {
+    return addDraftItem(config, `#${issueNumber}: ${title}`, body, status);
+  }
+}
+
+/**
  * Get all items from the project with their status.
  */
 export async function getProjectItems(

--- a/src/triage.ts
+++ b/src/triage.ts
@@ -1,0 +1,223 @@
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import type Database from "better-sqlite3";
+import type { CommunityIssue } from "./issues.js";
+import { closeIssueWithComment } from "./issues.js";
+import { hasIssueAction, insertIssueAction } from "./db.js";
+import { addLinkedItem, type ProjectConfig, type ProjectItem } from "./planning.js";
+import { detectRepo, isValidRepo } from "./issues.js";
+
+// --- Types ---
+
+export interface TriageDecision {
+  issueNumber: number;
+  action: "add_to_backlog" | "already_done" | "not_applicable";
+  reason: string;
+}
+
+export interface TriageResult {
+  decisions: TriageDecision[];
+  addedToBacklog: number[];
+  closed: number[];
+}
+
+// --- Prompt Building ---
+
+export function buildTriagePrompt(
+  issues: CommunityIssue[],
+  boardItems: ProjectItem[],
+): string {
+  const issueList = issues
+    .map(
+      (i) =>
+        `- #${i.number}: "${i.title}" (${i.reactions} reactions)\n  ${i.body.slice(0, 300)}`,
+    )
+    .join("\n");
+
+  const boardList =
+    boardItems.length > 0
+      ? boardItems
+          .map(
+            (item) =>
+              `- [${item.status ?? "No Status"}] ${item.title}${item.linkedIssueNumber ? ` (#${item.linkedIssueNumber})` : ""}`,
+          )
+          .join("\n")
+      : "No items on board yet.";
+
+  return `You are Bloom, a self-evolving coding agent. You need to triage new community issues.
+
+For each issue below, decide one of:
+- "add_to_backlog": Valid work request — add to the project board backlog for future cycles.
+- "already_done": This capability/fix already exists in the codebase or board.
+- "not_applicable": Not relevant, not actionable, or out of scope.
+
+## New issues to triage:
+${issueList}
+
+## Current project board state:
+${boardList}
+
+Respond with ONLY a JSON array of objects. No other text. Example:
+[{"issueNumber": 1, "action": "add_to_backlog", "reason": "Valid feature request for improving error messages."}]`;
+}
+
+// --- Response Parsing ---
+
+export function parseTriageResponse(text: string): TriageDecision[] {
+  // Extract JSON from potentially fenced markdown
+  const fenceMatch = text.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+  const jsonStr = fenceMatch ? fenceMatch[1] : text.trim();
+
+  try {
+    const parsed = JSON.parse(jsonStr);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter(
+      (item): item is TriageDecision =>
+        typeof item === "object" &&
+        item !== null &&
+        typeof item.issueNumber === "number" &&
+        ["add_to_backlog", "already_done", "not_applicable"].includes(
+          item.action,
+        ) &&
+        typeof item.reason === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+// --- Main Triage Function ---
+
+export async function triageIssues(
+  issues: CommunityIssue[],
+  boardItems: ProjectItem[],
+  cycleCount: number,
+  projectConfig: ProjectConfig,
+  db?: Database.Database,
+): Promise<TriageResult> {
+  const result: TriageResult = {
+    decisions: [],
+    addedToBacklog: [],
+    closed: [],
+  };
+
+  if (issues.length === 0) return result;
+
+  // Filter out issues already on the board (by linkedIssueNumber)
+  const boardIssueNumbers = new Set(
+    boardItems
+      .map((item) => item.linkedIssueNumber)
+      .filter((n): n is number => n !== null),
+  );
+
+  // Close any issues that are already on the board but still open
+  const alreadyOnBoard = issues.filter((i) => boardIssueNumbers.has(i.number));
+  for (const issue of alreadyOnBoard) {
+    if (db && hasIssueAction(db, issue.number, "triaged")) continue;
+    await closeIssueWithComment(
+      issue.number,
+      cycleCount,
+      "This issue is already tracked on the Bloom Evolution Roadmap project board.",
+      db,
+      "triaged",
+    );
+    result.closed.push(issue.number);
+  }
+
+  // New issues that need triage
+  const newIssues = issues.filter((i) => !boardIssueNumbers.has(i.number));
+
+  // Also filter out any issues already triaged in this or a previous cycle
+  const untriaged = newIssues.filter(
+    (i) => !db || !hasIssueAction(db, i.number, "triaged"),
+  );
+
+  if (untriaged.length === 0) return result;
+
+  // Call LLM for triage decisions
+  const prompt = buildTriagePrompt(untriaged, boardItems);
+  let triageText = "";
+
+  try {
+    for await (const msg of query({
+      prompt,
+      options: {
+        model: "claude-sonnet-4-20250514",
+        maxTurns: 3,
+        maxBudgetUsd: 0.5,
+        permissionMode: "dontAsk",
+        allowedTools: [],
+      },
+    })) {
+      if ("result" in msg) triageText = msg.result;
+    }
+  } catch (err) {
+    console.error(`[triage] LLM call failed (non-fatal): ${(err as Error).message}`);
+    return result;
+  }
+
+  const decisions = parseTriageResponse(triageText);
+  result.decisions = decisions;
+
+  // Validate decisions against our actual issue set
+  const untriagedNumbers = new Set(untriaged.map((i) => i.number));
+  const repo = detectRepo();
+
+  for (const decision of decisions) {
+    if (!untriagedNumbers.has(decision.issueNumber)) continue;
+    const issue = untriaged.find((i) => i.number === decision.issueNumber);
+    if (!issue) continue;
+
+    try {
+      switch (decision.action) {
+        case "add_to_backlog": {
+          if (repo && isValidRepo(repo)) {
+            await addLinkedItem(
+              projectConfig,
+              repo,
+              issue.number,
+              issue.title,
+              issue.body,
+            );
+          }
+          await closeIssueWithComment(
+            issue.number,
+            cycleCount,
+            `Added to Bloom Evolution Roadmap backlog (cycle ${cycleCount}).\n\n${decision.reason}`,
+            db,
+            "triaged",
+          );
+          result.addedToBacklog.push(issue.number);
+          result.closed.push(issue.number);
+          break;
+        }
+        case "already_done": {
+          await closeIssueWithComment(
+            issue.number,
+            cycleCount,
+            `Closing — this appears to already be addressed (cycle ${cycleCount}).\n\n${decision.reason}`,
+            db,
+            "triaged",
+          );
+          result.closed.push(issue.number);
+          break;
+        }
+        case "not_applicable": {
+          await closeIssueWithComment(
+            issue.number,
+            cycleCount,
+            `Closing — not applicable or out of scope (cycle ${cycleCount}).\n\n${decision.reason}`,
+            db,
+            "triaged",
+          );
+          result.closed.push(issue.number);
+          break;
+        }
+      }
+    } catch {
+      // Best-effort: don't let a single issue failure block others
+    }
+  }
+
+  return result;
+}

--- a/tests/evolve.test.ts
+++ b/tests/evolve.test.ts
@@ -6,42 +6,25 @@ describe("buildAssessmentPrompt", () => {
     const prompt = buildAssessmentPrompt({
       identity: "I am Bloom",
       journalSummary: "# Journal",
-      issues: [],
       cycleCount: 5,
     });
     expect(prompt).toContain("evolution cycle 5");
     expect(prompt).toContain("I am Bloom");
   });
 
-  it("includes community issues sorted by reactions", () => {
+  it("references project board for community work", () => {
     const prompt = buildAssessmentPrompt({
       identity: "test",
       journalSummary: "",
-      issues: [
-        { number: 1, title: "Add feature X", body: "", reactions: 10 },
-        { number: 2, title: "Fix bug Y", body: "", reactions: 5 },
-      ],
       cycleCount: 1,
     });
-    expect(prompt).toContain("#1: Add feature X (10 reactions)");
-    expect(prompt).toContain("#2: Fix bug Y (5 reactions)");
-  });
-
-  it("handles no issues gracefully", () => {
-    const prompt = buildAssessmentPrompt({
-      identity: "test",
-      journalSummary: "",
-      issues: [],
-      cycleCount: 1,
-    });
-    expect(prompt).toContain("No community issues");
+    expect(prompt).toContain("project board");
   });
 
   it("includes cycleStatsText in prompt when provided", () => {
     const prompt = buildAssessmentPrompt({
       identity: "test",
       journalSummary: "",
-      issues: [],
       cycleCount: 10,
       cycleStatsText: "Total cycles: 9 | Success rate: 78%",
     });
@@ -53,7 +36,6 @@ describe("buildAssessmentPrompt", () => {
     const prompt = buildAssessmentPrompt({
       identity: "test",
       journalSummary: "",
-      issues: [],
       cycleCount: 10,
     });
     expect(prompt).not.toContain("track record");
@@ -63,7 +45,6 @@ describe("buildAssessmentPrompt", () => {
     const prompt = buildAssessmentPrompt({
       identity: "test",
       journalSummary: "",
-      issues: [],
       cycleCount: 5,
       memoryContext: "[pattern] Always run tests before committing",
     });
@@ -75,7 +56,6 @@ describe("buildAssessmentPrompt", () => {
     const prompt = buildAssessmentPrompt({
       identity: "test",
       journalSummary: "",
-      issues: [],
       cycleCount: 5,
     });
     expect(prompt).not.toContain("accumulated knowledge");
@@ -85,7 +65,6 @@ describe("buildAssessmentPrompt", () => {
     const prompt = buildAssessmentPrompt({
       identity: "test",
       journalSummary: "",
-      issues: [],
       cycleCount: 5,
       planningContext: "Current item: Improve error handling",
     });
@@ -96,7 +75,6 @@ describe("buildAssessmentPrompt", () => {
     const prompt = buildAssessmentPrompt({
       identity: "test",
       journalSummary: "",
-      issues: [],
       cycleCount: 5,
     });
     expect(prompt).not.toContain("Current item");
@@ -106,7 +84,6 @@ describe("buildAssessmentPrompt", () => {
     const prompt = buildAssessmentPrompt({
       identity: "test",
       journalSummary: "## Cycle 5 — 2026-03-06\nSome content here",
-      issues: [],
       cycleCount: 6,
     });
     expect(prompt).toContain("Cycle 5");

--- a/tests/issues.test.ts
+++ b/tests/issues.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { execFileSync } from "child_process";
-import { fetchCommunityIssues, acknowledgeIssues, closeResolvedIssue, hasCommitForIssue, isValidRepo, isSafeIssueNumber, detectRepo } from "../src/issues.js";
+import { fetchCommunityIssues, acknowledgeIssues, closeResolvedIssue, closeIssueWithComment, hasCommitForIssue, isValidRepo, isSafeIssueNumber, detectRepo } from "../src/issues.js";
 import { githubApiRequest } from "../src/github-app.js";
 import { initDb, hasIssueAction } from "../src/db.js";
 
@@ -601,6 +601,58 @@ describe("acknowledgeIssues — DB idempotency", () => {
     expect(hasIssueAction(db, 7, "acknowledged")).toBe(true);
     // Only 1 API call (GET comments), no POST
     expect(mockGithubApiRequest).toHaveBeenCalledTimes(1);
+
+    db.close();
+  });
+});
+
+describe("closeIssueWithComment", () => {
+  const originalEnv = process.env.GITHUB_REPOSITORY;
+
+  afterEach(() => {
+    mockGithubApiRequest.mockReset();
+    if (originalEnv !== undefined) {
+      process.env.GITHUB_REPOSITORY = originalEnv;
+    } else {
+      delete process.env.GITHUB_REPOSITORY;
+    }
+  });
+
+  it("posts a custom comment and closes the issue", async () => {
+    process.env.GITHUB_REPOSITORY = "owner/repo";
+    mockGithubApiRequest.mockResolvedValueOnce({ ok: true } as Response);
+    mockGithubApiRequest.mockResolvedValueOnce({ ok: true } as Response);
+
+    const result = await closeIssueWithComment(5, 10, "Custom triage message");
+    expect(result).toBe(true);
+    expect(mockGithubApiRequest).toHaveBeenCalledWith(
+      "POST",
+      "/repos/owner/repo/issues/5/comments",
+      { body: "Custom triage message" },
+    );
+    expect(mockGithubApiRequest).toHaveBeenCalledWith(
+      "PATCH",
+      "/repos/owner/repo/issues/5",
+      { state: "closed" },
+    );
+  });
+
+  it("uses custom action type for DB idempotency", async () => {
+    process.env.GITHUB_REPOSITORY = "owner/repo";
+    const db = initDb(":memory:");
+    db.prepare("INSERT INTO cycles (cycle_number, started_at) VALUES (?, ?)").run(10, new Date().toISOString());
+
+    mockGithubApiRequest.mockResolvedValueOnce({ ok: true } as Response);
+    mockGithubApiRequest.mockResolvedValueOnce({ ok: true } as Response);
+
+    await closeIssueWithComment(5, 10, "Triaged", db, "triaged");
+    expect(hasIssueAction(db, 5, "triaged")).toBe(true);
+
+    // Second call skips
+    mockGithubApiRequest.mockReset();
+    const result = await closeIssueWithComment(5, 10, "Triaged", db, "triaged");
+    expect(result).toBe(true);
+    expect(mockGithubApiRequest).not.toHaveBeenCalled();
 
     db.close();
   });

--- a/tests/planning-async.test.ts
+++ b/tests/planning-async.test.ts
@@ -10,7 +10,7 @@ vi.mock("../src/issues.js", () => ({
   isValidRepo: vi.fn(),
 }));
 
-import { ensureProject, getProjectItems, addDraftItem, updateItemStatus, type ProjectConfig } from "../src/planning.js";
+import { ensureProject, getProjectItems, addDraftItem, updateItemStatus, getIssueNodeId, addLinkedItem, type ProjectConfig } from "../src/planning.js";
 import { githubGraphQL } from "../src/github-app.js";
 import { detectRepo, isValidRepo } from "../src/issues.js";
 
@@ -356,5 +356,108 @@ describe("updateItemStatus", () => {
 
     const result = await updateItemStatus(config, "item-1", "Done");
     expect(result).toBe(false);
+  });
+});
+
+describe("getIssueNodeId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("resolves an issue number to a node ID", async () => {
+    mockGraphQL.mockResolvedValueOnce({
+      data: { repository: { issue: { id: "I_abc123" } } },
+    });
+
+    const nodeId = await getIssueNodeId("owner/repo", 42);
+    expect(nodeId).toBe("I_abc123");
+    expect(mockGraphQL).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when issue does not exist", async () => {
+    mockGraphQL.mockResolvedValueOnce({
+      data: { repository: { issue: null } },
+    });
+
+    const nodeId = await getIssueNodeId("owner/repo", 999);
+    expect(nodeId).toBeNull();
+  });
+
+  it("returns null when GraphQL throws", async () => {
+    mockGraphQL.mockRejectedValueOnce(new Error("Network error"));
+
+    const nodeId = await getIssueNodeId("owner/repo", 1);
+    expect(nodeId).toBeNull();
+  });
+
+  it("returns null for invalid repo format", async () => {
+    const nodeId = await getIssueNodeId("invalid", 1);
+    expect(nodeId).toBeNull();
+  });
+});
+
+describe("addLinkedItem", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("adds a real issue to the project by node ID", async () => {
+    const config = makeConfig();
+    // getIssueNodeId
+    mockGraphQL.mockResolvedValueOnce({
+      data: { repository: { issue: { id: "I_abc123" } } },
+    });
+    // addProjectV2ItemById
+    mockGraphQL.mockResolvedValueOnce({
+      data: { addProjectV2ItemById: { item: { id: "proj-item-1" } } },
+    });
+    // updateItemStatus
+    mockGraphQL.mockResolvedValueOnce({
+      data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: "proj-item-1" } } },
+    });
+
+    const itemId = await addLinkedItem(config, "owner/repo", 42, "Fix bug", "Description");
+    expect(itemId).toBe("proj-item-1");
+    expect(mockGraphQL).toHaveBeenCalledTimes(3);
+  });
+
+  it("falls back to draft item when node ID lookup fails", async () => {
+    const config = makeConfig();
+    // getIssueNodeId fails
+    mockGraphQL.mockRejectedValueOnce(new Error("Not found"));
+    // addDraftItem
+    mockGraphQL.mockResolvedValueOnce({
+      data: { addProjectV2DraftIssue: { projectItem: { id: "draft-1" } } },
+    });
+    // updateItemStatus for draft
+    mockGraphQL.mockResolvedValueOnce({
+      data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: "draft-1" } } },
+    });
+
+    const itemId = await addLinkedItem(config, "owner/repo", 42, "Fix bug", "Description");
+    expect(itemId).toBe("draft-1");
+  });
+
+  it("falls back to draft when addProjectV2ItemById returns null", async () => {
+    const config = makeConfig();
+    // getIssueNodeId succeeds
+    mockGraphQL.mockResolvedValueOnce({
+      data: { repository: { issue: { id: "I_abc123" } } },
+    });
+    // addProjectV2ItemById returns null
+    mockGraphQL.mockResolvedValueOnce({
+      data: { addProjectV2ItemById: { item: null } },
+    });
+    // addDraftItem fallback
+    mockGraphQL.mockResolvedValueOnce({
+      data: { addProjectV2DraftIssue: { projectItem: { id: "draft-2" } } },
+    });
+    // updateItemStatus for draft
+    mockGraphQL.mockResolvedValueOnce({
+      data: { updateProjectV2ItemFieldValue: { projectV2Item: { id: "draft-2" } } },
+    });
+
+    const itemId = await addLinkedItem(config, "owner/repo", 42, "Fix bug", "Description");
+    expect(itemId).toBe("draft-2");
   });
 });

--- a/tests/triage.test.ts
+++ b/tests/triage.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "vitest";
+import { buildTriagePrompt, parseTriageResponse } from "../src/triage.js";
+import type { CommunityIssue } from "../src/issues.js";
+import type { ProjectItem } from "../src/planning.js";
+
+function makeIssue(overrides: Partial<CommunityIssue> = {}): CommunityIssue {
+  return {
+    number: 1,
+    title: "Test issue",
+    body: "Test body",
+    reactions: 0,
+    ...overrides,
+  };
+}
+
+function makeBoardItem(overrides: Partial<ProjectItem> = {}): ProjectItem {
+  return {
+    id: "item-1",
+    title: "Board item",
+    body: "",
+    status: "Backlog",
+    fieldValueId: null,
+    linkedIssueNumber: null,
+    reactions: 0,
+    ...overrides,
+  };
+}
+
+describe("buildTriagePrompt", () => {
+  it("includes issue numbers and titles", () => {
+    const issues = [makeIssue({ number: 5, title: "Add logging" })];
+    const prompt = buildTriagePrompt(issues, []);
+    expect(prompt).toContain("#5");
+    expect(prompt).toContain("Add logging");
+  });
+
+  it("includes board item state", () => {
+    const items = [makeBoardItem({ title: "Improve error handling", status: "Up Next" })];
+    const prompt = buildTriagePrompt([], items);
+    expect(prompt).toContain("[Up Next] Improve error handling");
+  });
+
+  it("shows linked issue numbers on board items", () => {
+    const items = [makeBoardItem({ title: "Fix bug", linkedIssueNumber: 42 })];
+    const prompt = buildTriagePrompt([], items);
+    expect(prompt).toContain("(#42)");
+  });
+
+  it("handles empty board", () => {
+    const prompt = buildTriagePrompt([makeIssue()], []);
+    expect(prompt).toContain("No items on board yet");
+  });
+
+  it("includes triage action options in prompt", () => {
+    const prompt = buildTriagePrompt([makeIssue()], []);
+    expect(prompt).toContain("add_to_backlog");
+    expect(prompt).toContain("already_done");
+    expect(prompt).toContain("not_applicable");
+  });
+
+  it("truncates long issue bodies", () => {
+    const longBody = "x".repeat(500);
+    const prompt = buildTriagePrompt([makeIssue({ body: longBody })], []);
+    // Body should be truncated to 300 chars
+    expect(prompt).not.toContain("x".repeat(500));
+    expect(prompt).toContain("x".repeat(300));
+  });
+});
+
+describe("parseTriageResponse", () => {
+  it("parses a clean JSON array", () => {
+    const input = `[{"issueNumber": 1, "action": "add_to_backlog", "reason": "Valid feature request."}]`;
+    const result = parseTriageResponse(input);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      issueNumber: 1,
+      action: "add_to_backlog",
+      reason: "Valid feature request.",
+    });
+  });
+
+  it("parses JSON inside markdown code fences", () => {
+    const input = "```json\n[{\"issueNumber\": 2, \"action\": \"already_done\", \"reason\": \"Already exists.\"}]\n```";
+    const result = parseTriageResponse(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].action).toBe("already_done");
+  });
+
+  it("parses JSON inside plain code fences", () => {
+    const input = "```\n[{\"issueNumber\": 3, \"action\": \"not_applicable\", \"reason\": \"Out of scope.\"}]\n```";
+    const result = parseTriageResponse(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].action).toBe("not_applicable");
+  });
+
+  it("returns empty array for invalid JSON", () => {
+    expect(parseTriageResponse("not json at all")).toEqual([]);
+  });
+
+  it("returns empty array for non-array JSON", () => {
+    expect(parseTriageResponse('{"issueNumber": 1}')).toEqual([]);
+  });
+
+  it("filters out entries with invalid action values", () => {
+    const input = `[
+      {"issueNumber": 1, "action": "add_to_backlog", "reason": "Good"},
+      {"issueNumber": 2, "action": "invalid_action", "reason": "Bad"}
+    ]`;
+    const result = parseTriageResponse(input);
+    expect(result).toHaveLength(1);
+    expect(result[0].issueNumber).toBe(1);
+  });
+
+  it("filters out entries missing required fields", () => {
+    const input = `[
+      {"issueNumber": 1, "action": "add_to_backlog", "reason": "Good"},
+      {"action": "already_done", "reason": "Missing number"},
+      {"issueNumber": 3, "reason": "Missing action"}
+    ]`;
+    const result = parseTriageResponse(input);
+    expect(result).toHaveLength(1);
+  });
+
+  it("handles multiple valid decisions", () => {
+    const input = `[
+      {"issueNumber": 1, "action": "add_to_backlog", "reason": "Feature request"},
+      {"issueNumber": 2, "action": "already_done", "reason": "Already implemented"},
+      {"issueNumber": 3, "action": "not_applicable", "reason": "Not relevant"}
+    ]`;
+    const result = parseTriageResponse(input);
+    expect(result).toHaveLength(3);
+  });
+
+  it("handles empty array", () => {
+    expect(parseTriageResponse("[]")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Introduces an automated issue triage system that uses Claude to categorize incoming community issues and manage their lifecycle. Issues are now triaged against the project board and either added to the backlog, closed as already-done, or closed as out-of-scope—replacing the previous manual acknowledgment flow.

## Key Changes

- **New triage module** (`src/triage.ts`): 
  - `triageIssues()` function that uses Claude to evaluate issues and make categorization decisions
  - `buildTriagePrompt()` constructs context-aware prompts including current board state
  - `parseTriageResponse()` safely extracts and validates LLM decisions from JSON responses
  - Handles three outcomes: `add_to_backlog`, `already_done`, `not_applicable`

- **Enhanced issue management** (`src/issues.ts`):
  - Refactored `closeResolvedIssue()` → `closeIssueWithComment()` for generic issue closing with custom comments
  - Supports custom action types for DB idempotency (e.g., "triaged" vs "closed")
  - Maintains backward compatibility with deprecated wrapper

- **Project board linking** (`src/planning.ts`):
  - New `getIssueNodeId()` function to resolve GitHub issue numbers to GraphQL node IDs
  - New `addLinkedItem()` function to add real GitHub issues to the project board (not just drafts)
  - Gracefully falls back to draft items if linking fails

- **Integration into main cycle** (`src/index.ts`):
  - Triage step runs after fetching community issues and before evolution planning
  - Re-fetches board items post-triage to reflect newly added issues
  - Logs triage decisions and outcomes

- **Removed legacy flow** (`src/evolve.ts`, `src/orchestrator.ts`):
  - Removed community issues from assessment context (no longer needed—board items are the source of truth)
  - Removed `extractResolvedIssueNumbers()` and issue closing from evolution processing
  - Issue lifecycle is now owned by the triage step, not the evolution step

- **Comprehensive test coverage** (`tests/triage.test.ts`):
  - Tests for prompt building with various board states
  - Tests for JSON parsing with markdown fences and edge cases
  - Tests for filtering invalid decisions

- **Updated existing tests** (`tests/planning-async.test.ts`, `tests/issues.test.ts`, `tests/evolve.test.ts`):
  - Added tests for `getIssueNodeId()` and `addLinkedItem()` with fallback scenarios
  - Added tests for `closeIssueWithComment()` with custom action types
  - Updated assessment prompt tests to reflect removal of issues parameter

## Implementation Details

- Triage decisions are validated against the actual issue set to prevent processing stale or invalid decisions
- DB idempotency prevents duplicate triage actions across cycles
- Issues already on the board are automatically closed with a comment
- LLM failures are non-fatal and logged; the cycle continues
- All issue operations use best-effort error handling to prevent single-issue failures from blocking others

https://claude.ai/code/session_01BZYT5Ewq9JX4m91vBkj3Pa